### PR TITLE
Making the servers object use typed servernames instead of "string"

### DIFF
--- a/snapshotTests/snapshot/infectionTracker/api.ts
+++ b/snapshotTests/snapshot/infectionTracker/api.ts
@@ -253,7 +253,11 @@ export class ExposuresApi extends BaseAPI implements ExposuresApiInterface {
     }
 }
 
-export const servers: Record<string, ApplicationApis> = {
+type ServerNames =
+    | "current"
+    | "production";
+
+export const servers: Record<ServerNames, ApplicationApis> = {
     "current": {
         caseWorkersApi: new CaseWorkersApi("/api"),
         casesApi: new CasesApi("/api"),

--- a/snapshotTests/snapshot/petstore/api.ts
+++ b/snapshotTests/snapshot/petstore/api.ts
@@ -633,7 +633,10 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     }
 }
 
-export const servers: Record<string, ApplicationApis> = {
+type ServerNames =
+    | "default";
+
+export const servers: Record<ServerNames, ApplicationApis> = {
     default: {
         petApi: new PetApi("http://petstore.swagger.io/v2"),
         storeApi: new StoreApi("http://petstore.swagger.io/v2"),

--- a/snapshotTests/snapshot/poly/api.ts
+++ b/snapshotTests/snapshot/poly/api.ts
@@ -114,7 +114,10 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     }
 }
 
-export const servers: Record<string, ApplicationApis> = {
+type ServerNames =
+    | "default";
+
+export const servers: Record<ServerNames, ApplicationApis> = {
     default: {
         defaultApi: new DefaultApi("/"),
     },

--- a/snapshotTests/snapshot/typeHierarchy/api.ts
+++ b/snapshotTests/snapshot/typeHierarchy/api.ts
@@ -63,7 +63,11 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     }
 }
 
-export const servers: Record<string, ApplicationApis> = {
+type ServerNames =
+    | "Optional server description, e.g. Main (production) server"
+    | "Optional server description, e.g. Internal staging server for testing";
+
+export const servers: Record<ServerNames, ApplicationApis> = {
     "Optional server description, e.g. Main (production) server": {
         defaultApi: new DefaultApi("http://api.example.com/v1"),
     },

--- a/src/main/resources/typescript-fetch-api/api.handlebars
+++ b/src/main/resources/typescript-fetch-api/api.handlebars
@@ -20,7 +20,12 @@ export interface ApplicationApis {
 {{~/withInterfaces}}
 {{#apiInfo}}{{#apis}}{{>apiInner}}{{/apis}}{{/apiInfo}}
 
-export const servers: Record<string, ApplicationApis> = {
+type ServerNames =
+{{~#servers}}
+    | "{{#if description}}{{description}}{{else}}default{{/if}}"
+{{~/servers}};
+
+export const servers: Record<ServerNames, ApplicationApis> = {
 {{~#servers}}
     {{#if description}}"{{description}}"{{else}}default{{/if}}: {
     {{~#apiInfo}}{{#apis}}


### PR DESCRIPTION
Easier to use the server constant. Ts will help to provide an allowed server name. Without this any string can be provided and will fail later on.