### PR TITLE
refactor: use const assertion for OpenAPI "enum" arrays

### DIFF
--- a/snapshotTests/snapshot/bigExample/test/modelTest.ts
+++ b/snapshotTests/snapshot/bigExample/test/modelTest.ts
@@ -32,12 +32,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -122,15 +122,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -142,7 +142,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -218,7 +218,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -306,7 +306,7 @@ export class TestSampleData {
     sampleArrayPetDto(
         length?: number,
         template?: Factory<PetDto>
-    ): Array<PetDto> {
+    ): readonly PetDto[] {
         return this.randomArray(
             () => this.samplePetDto(template),
             length ?? this.arrayLength()
@@ -332,7 +332,7 @@ export class TestSampleData {
     sampleArrayPetLocationsDto(
         length?: number,
         template?: Factory<PetLocationsDto>
-    ): Array<PetLocationsDto> {
+    ): readonly PetLocationsDto[] {
         return this.randomArray(
             () => this.samplePetLocationsDto(template),
             length ?? this.arrayLength()
@@ -356,7 +356,7 @@ export class TestSampleData {
     sampleArrayPetStoreDto(
         length?: number,
         template?: Factory<PetStoreDto>
-    ): Array<PetStoreDto> {
+    ): readonly PetStoreDto[] {
         return this.randomArray(
             () => this.samplePetStoreDto(template),
             length ?? this.arrayLength()

--- a/snapshotTests/snapshot/example/model.ts
+++ b/snapshotTests/snapshot/example/model.ts
@@ -19,6 +19,6 @@ export const PetTypeDtoValues = [
     "cat",
     "dog",
     "bird",
-];
+] as const;
 
 export type PetTypeDto = typeof PetTypeDtoValues[number];

--- a/snapshotTests/snapshot/example/test/modelTest.ts
+++ b/snapshotTests/snapshot/example/test/modelTest.ts
@@ -32,12 +32,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -121,15 +121,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -141,7 +141,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -217,7 +217,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -301,7 +301,7 @@ export class TestSampleData {
     sampleArrayPetDto(
         length?: number,
         template?: Factory<PetDto>
-    ): Array<PetDto> {
+    ): readonly PetDto[] {
         return this.randomArray(
             () => this.samplePetDto(template),
             length ?? this.arrayLength()
@@ -316,7 +316,7 @@ export class TestSampleData {
         return this.pickOne(PetTypeDtoValues);
     }
 
-    sampleArrayPetTypeDto(length?: number): Array<PetTypeDto> {
+    sampleArrayPetTypeDto(length?: number): readonly PetTypeDto[] {
         return this.randomArray(
             () => this.samplePetTypeDto(),
             length ?? this.arrayLength()

--- a/snapshotTests/snapshot/geojson/model.ts
+++ b/snapshotTests/snapshot/geojson/model.ts
@@ -27,7 +27,7 @@ export const GeometryDtoDescriminators = [
     "Point",
     "Polygon",
     "LineString",
-];
+] as const;
 
 export type GeometryDtoDescriminator = typeof GeometryDtoDescriminators[number];
 

--- a/snapshotTests/snapshot/geojson/test/modelTest.ts
+++ b/snapshotTests/snapshot/geojson/test/modelTest.ts
@@ -34,12 +34,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -126,15 +126,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -146,7 +146,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -222,7 +222,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -309,7 +309,7 @@ export class TestSampleData {
     sampleArrayGeometryCollectionDto(
         length?: number,
         template?: Factory<GeometryCollectionDto>
-    ): Array<GeometryCollectionDto> {
+    ): readonly GeometryCollectionDto[] {
         return this.randomArray(
             () => this.sampleGeometryCollectionDto(template),
             length ?? this.arrayLength()
@@ -349,7 +349,7 @@ export class TestSampleData {
     sampleArrayGeometryDto(
         length?: number,
         factory?: (sampleData: TestSampleData) => GeometryDto
-    ): Array<GeometryDto> {
+    ): readonly GeometryDto[] {
         return this.randomArray(
             () => this.sampleGeometryDto(factory),
             length ?? this.arrayLength()
@@ -376,7 +376,7 @@ export class TestSampleData {
     sampleArrayLineStringDto(
         length?: number,
         template?: Factory<LineStringDto>
-    ): Array<LineStringDto> {
+    ): readonly LineStringDto[] {
         return this.randomArray(
             () => this.sampleLineStringDto(template),
             length ?? this.arrayLength()
@@ -401,7 +401,7 @@ export class TestSampleData {
     sampleArrayPointDto(
         length?: number,
         template?: Factory<PointDto>
-    ): Array<PointDto> {
+    ): readonly PointDto[] {
         return this.randomArray(
             () => this.samplePointDto(template),
             length ?? this.arrayLength()
@@ -428,7 +428,7 @@ export class TestSampleData {
     sampleArrayPolygonDto(
         length?: number,
         template?: Factory<PolygonDto>
-    ): Array<PolygonDto> {
+    ): readonly PolygonDto[] {
         return this.randomArray(
             () => this.samplePolygonDto(template),
             length ?? this.arrayLength()

--- a/snapshotTests/snapshot/infectionTracker/model.ts
+++ b/snapshotTests/snapshot/infectionTracker/model.ts
@@ -44,7 +44,7 @@ export const ExposureDtoStatusEnumValues = [
     "contacted",
     "tested",
     "infected",
-];
+] as const;
 
 export type ExposureDtoStatusEnum = typeof ExposureDtoStatusEnumValues[number];
 
@@ -56,7 +56,7 @@ export const ExposureDtoDelayAfterInfectionEnumValues = [
     2,
     3,
     4,
-];
+] as const;
 
 export type ExposureDtoDelayAfterInfectionEnum = typeof ExposureDtoDelayAfterInfectionEnumValues[number];
 
@@ -79,6 +79,6 @@ export const UserRoleDtoValues = [
     "administrator",
     "interviewer",
     "followup",
-];
+] as const;
 
 export type UserRoleDto = typeof UserRoleDtoValues[number];

--- a/snapshotTests/snapshot/infectionTracker/test/modelTest.ts
+++ b/snapshotTests/snapshot/infectionTracker/test/modelTest.ts
@@ -37,12 +37,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -129,15 +129,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -149,7 +149,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -225,7 +225,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -326,7 +326,7 @@ export class TestSampleData {
     sampleArrayCaseWorkerDto(
         length?: number,
         template?: Factory<CaseWorkerDto>
-    ): Array<CaseWorkerDto> {
+    ): readonly CaseWorkerDto[] {
         return this.randomArray(
             () => this.sampleCaseWorkerDto(template),
             length ?? this.arrayLength()
@@ -390,7 +390,7 @@ export class TestSampleData {
     sampleArrayExposureDto(
         length?: number,
         template?: Factory<ExposureDto>
-    ): Array<ExposureDto> {
+    ): readonly ExposureDto[] {
         return this.randomArray(
             () => this.sampleExposureDto(template),
             length ?? this.arrayLength()
@@ -424,7 +424,7 @@ export class TestSampleData {
     sampleArrayInfectionDto(
         length?: number,
         template?: Factory<InfectionDto>
-    ): Array<InfectionDto> {
+    ): readonly InfectionDto[] {
         return this.randomArray(
             () => this.sampleInfectionDto(template),
             length ?? this.arrayLength()
@@ -463,7 +463,7 @@ export class TestSampleData {
     sampleArrayInfectionInformationDto(
         length?: number,
         template?: Factory<InfectionInformationDto>
-    ): Array<InfectionInformationDto> {
+    ): readonly InfectionInformationDto[] {
         return this.randomArray(
             () => this.sampleInfectionInformationDto(template),
             length ?? this.arrayLength()
@@ -478,7 +478,7 @@ export class TestSampleData {
         return this.pickOne(UserRoleDtoValues);
     }
 
-    sampleArrayUserRoleDto(length?: number): Array<UserRoleDto> {
+    sampleArrayUserRoleDto(length?: number): readonly UserRoleDto[] {
         return this.randomArray(
             () => this.sampleUserRoleDto(),
             length ?? this.arrayLength()

--- a/snapshotTests/snapshot/openid-configuration/model.ts
+++ b/snapshotTests/snapshot/openid-configuration/model.ts
@@ -28,34 +28,34 @@ export const DiscoveryDocumentDtoResponseTypesSupportedEnumValues = [
     "code",
     "token",
     "id_token",
-];
+] as const;
 
 export type DiscoveryDocumentDtoResponseTypesSupportedEnum = typeof DiscoveryDocumentDtoResponseTypesSupportedEnumValues[number];
 
 export const DiscoveryDocumentDtoResponseModesSupportedEnumValues = [
     "query",
     "fragment",
-];
+] as const;
 
 export type DiscoveryDocumentDtoResponseModesSupportedEnum = typeof DiscoveryDocumentDtoResponseModesSupportedEnumValues[number];
 
 export const DiscoveryDocumentDtoSubjectTypesSupportedEnumValues = [
     "pairwise",
     "public",
-];
+] as const;
 
 export type DiscoveryDocumentDtoSubjectTypesSupportedEnum = typeof DiscoveryDocumentDtoSubjectTypesSupportedEnumValues[number];
 
 export const DiscoveryDocumentDtoCodeChallengeMethodsSupportedEnumValues = [
     "S256",
     "plain",
-];
+] as const;
 
 export type DiscoveryDocumentDtoCodeChallengeMethodsSupportedEnum = typeof DiscoveryDocumentDtoCodeChallengeMethodsSupportedEnumValues[number];
 
 export const DiscoveryDocumentDtoIdTokenSigningAlgValuesSupportedEnumValues = [
     "RS256",
-];
+] as const;
 
 export type DiscoveryDocumentDtoIdTokenSigningAlgValuesSupportedEnum = typeof DiscoveryDocumentDtoIdTokenSigningAlgValuesSupportedEnumValues[number];
 

--- a/snapshotTests/snapshot/openid-configuration/test/modelTest.ts
+++ b/snapshotTests/snapshot/openid-configuration/test/modelTest.ts
@@ -35,12 +35,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -128,15 +128,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -148,7 +148,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -224,7 +224,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -364,7 +364,7 @@ export class TestSampleData {
     sampleArrayDiscoveryDocumentDto(
         length?: number,
         template?: Factory<DiscoveryDocumentDto>
-    ): Array<DiscoveryDocumentDto> {
+    ): readonly DiscoveryDocumentDto[] {
         return this.randomArray(
             () => this.sampleDiscoveryDocumentDto(template),
             length ?? this.arrayLength()
@@ -388,7 +388,7 @@ export class TestSampleData {
     sampleArrayJwksDocumentDto(
         length?: number,
         template?: Factory<JwksDocumentDto>
-    ): Array<JwksDocumentDto> {
+    ): readonly JwksDocumentDto[] {
         return this.randomArray(
             () => this.sampleJwksDocumentDto(template),
             length ?? this.arrayLength()
@@ -427,7 +427,7 @@ export class TestSampleData {
     sampleArrayJwksKeyDto(
         length?: number,
         template?: Factory<JwksKeyDto>
-    ): Array<JwksKeyDto> {
+    ): readonly JwksKeyDto[] {
         return this.randomArray(
             () => this.sampleJwksKeyDto(template),
             length ?? this.arrayLength()
@@ -461,7 +461,7 @@ export class TestSampleData {
     sampleArrayJwtHeaderDto(
         length?: number,
         template?: Factory<JwtHeaderDto>
-    ): Array<JwtHeaderDto> {
+    ): readonly JwtHeaderDto[] {
         return this.randomArray(
             () => this.sampleJwtHeaderDto(template),
             length ?? this.arrayLength()
@@ -520,7 +520,7 @@ export class TestSampleData {
     sampleArrayJwtPayloadDto(
         length?: number,
         template?: Factory<JwtPayloadDto>
-    ): Array<JwtPayloadDto> {
+    ): readonly JwtPayloadDto[] {
         return this.randomArray(
             () => this.sampleJwtPayloadDto(template),
             length ?? this.arrayLength()
@@ -569,7 +569,7 @@ export class TestSampleData {
     sampleArrayTokenResponseDto(
         length?: number,
         template?: Factory<TokenResponseDto>
-    ): Array<TokenResponseDto> {
+    ): readonly TokenResponseDto[] {
         return this.randomArray(
             () => this.sampleTokenResponseDto(template),
             length ?? this.arrayLength()

--- a/snapshotTests/snapshot/petstore/model.ts
+++ b/snapshotTests/snapshot/petstore/model.ts
@@ -31,7 +31,7 @@ export const OrderDtoStatusEnumValues = [
     "placed",
     "approved",
     "delivered",
-];
+] as const;
 
 /**
  * Order Status
@@ -54,7 +54,7 @@ export const PetDtoStatusEnumValues = [
     "available",
     "pending",
     "sold",
-];
+] as const;
 
 /**
  * pet status in the store

--- a/snapshotTests/snapshot/petstore/test/modelTest.ts
+++ b/snapshotTests/snapshot/petstore/test/modelTest.ts
@@ -36,12 +36,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -128,15 +128,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -148,7 +148,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -224,7 +224,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -315,7 +315,7 @@ export class TestSampleData {
     sampleArrayCategoryDto(
         length?: number,
         template?: Factory<CategoryDto>
-    ): Array<CategoryDto> {
+    ): readonly CategoryDto[] {
         return this.randomArray(
             () => this.sampleCategoryDto(template),
             length ?? this.arrayLength()
@@ -364,7 +364,7 @@ export class TestSampleData {
     sampleArrayOrderDto(
         length?: number,
         template?: Factory<OrderDto>
-    ): Array<OrderDto> {
+    ): readonly OrderDto[] {
         return this.randomArray(
             () => this.sampleOrderDto(template),
             length ?? this.arrayLength()
@@ -413,7 +413,7 @@ export class TestSampleData {
     sampleArrayPetDto(
         length?: number,
         template?: Factory<PetDto>
-    ): Array<PetDto> {
+    ): readonly PetDto[] {
         return this.randomArray(
             () => this.samplePetDto(template),
             length ?? this.arrayLength()
@@ -442,7 +442,7 @@ export class TestSampleData {
     sampleArrayTagDto(
         length?: number,
         template?: Factory<TagDto>
-    ): Array<TagDto> {
+    ): readonly TagDto[] {
         return this.randomArray(
             () => this.sampleTagDto(template),
             length ?? this.arrayLength()
@@ -501,7 +501,7 @@ export class TestSampleData {
     sampleArrayUserDto(
         length?: number,
         template?: Factory<UserDto>
-    ): Array<UserDto> {
+    ): readonly UserDto[] {
         return this.randomArray(
             () => this.sampleUserDto(template),
             length ?? this.arrayLength()

--- a/snapshotTests/snapshot/poly/model.ts
+++ b/snapshotTests/snapshot/poly/model.ts
@@ -17,7 +17,7 @@ export type AnyPartyDto =
 export const AnyPartyDtoDescriminators = [
     "organization",
     "person",
-];
+] as const;
 
 export type AnyPartyDtoDescriminator = typeof AnyPartyDtoDescriminators[number];
 
@@ -30,7 +30,7 @@ export const CreationErrorDtoDescriminators = [
     "IllegalEmailAddressError",
     "DuplicateIdentifierError",
     "GeneralError",
-];
+] as const;
 
 export type CreationErrorDtoDescriminator = typeof CreationErrorDtoDescriminators[number];
 
@@ -94,6 +94,6 @@ export const UpdateErrorDtoDescriminators = [
     "DuplicateIdentifierError",
     "GeneralError",
     "NotFoundError",
-];
+] as const;
 
 export type UpdateErrorDtoDescriminator = typeof UpdateErrorDtoDescriminators[number];

--- a/snapshotTests/snapshot/poly/test/modelTest.ts
+++ b/snapshotTests/snapshot/poly/test/modelTest.ts
@@ -39,12 +39,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -136,15 +136,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -156,7 +156,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -232,7 +232,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -349,7 +349,7 @@ export class TestSampleData {
     sampleArrayAnyPartyDto(
         length?: number,
         factory?: (sampleData: TestSampleData) => AnyPartyDto
-    ): Array<AnyPartyDto> {
+    ): readonly AnyPartyDto[] {
         return this.randomArray(
             () => this.sampleAnyPartyDto(factory),
             length ?? this.arrayLength()
@@ -389,7 +389,7 @@ export class TestSampleData {
     sampleArrayCreationErrorDto(
         length?: number,
         factory?: (sampleData: TestSampleData) => CreationErrorDto
-    ): Array<CreationErrorDto> {
+    ): readonly CreationErrorDto[] {
         return this.randomArray(
             () => this.sampleCreationErrorDto(factory),
             length ?? this.arrayLength()
@@ -423,7 +423,7 @@ export class TestSampleData {
     sampleArrayDuplicateIdentifierErrorDto(
         length?: number,
         template?: Factory<DuplicateIdentifierErrorDto>
-    ): Array<DuplicateIdentifierErrorDto> {
+    ): readonly DuplicateIdentifierErrorDto[] {
         return this.randomArray(
             () => this.sampleDuplicateIdentifierErrorDto(template),
             length ?? this.arrayLength()
@@ -452,7 +452,7 @@ export class TestSampleData {
     sampleArrayGeneralErrorDto(
         length?: number,
         template?: Factory<GeneralErrorDto>
-    ): Array<GeneralErrorDto> {
+    ): readonly GeneralErrorDto[] {
         return this.randomArray(
             () => this.sampleGeneralErrorDto(template),
             length ?? this.arrayLength()
@@ -486,7 +486,7 @@ export class TestSampleData {
     sampleArrayIllegalEmailAddressErrorDto(
         length?: number,
         template?: Factory<IllegalEmailAddressErrorDto>
-    ): Array<IllegalEmailAddressErrorDto> {
+    ): readonly IllegalEmailAddressErrorDto[] {
         return this.randomArray(
             () => this.sampleIllegalEmailAddressErrorDto(template),
             length ?? this.arrayLength()
@@ -515,7 +515,7 @@ export class TestSampleData {
     sampleArrayLogMessageDto(
         length?: number,
         template?: Factory<LogMessageDto>
-    ): Array<LogMessageDto> {
+    ): readonly LogMessageDto[] {
         return this.randomArray(
             () => this.sampleLogMessageDto(template),
             length ?? this.arrayLength()
@@ -549,7 +549,7 @@ export class TestSampleData {
     sampleArrayNotFoundErrorDto(
         length?: number,
         template?: Factory<NotFoundErrorDto>
-    ): Array<NotFoundErrorDto> {
+    ): readonly NotFoundErrorDto[] {
         return this.randomArray(
             () => this.sampleNotFoundErrorDto(template),
             length ?? this.arrayLength()
@@ -608,7 +608,7 @@ export class TestSampleData {
     sampleArrayOrganizationDto(
         length?: number,
         template?: Factory<OrganizationDto>
-    ): Array<OrganizationDto> {
+    ): readonly OrganizationDto[] {
         return this.randomArray(
             () => this.sampleOrganizationDto(template),
             length ?? this.arrayLength()
@@ -662,7 +662,7 @@ export class TestSampleData {
     sampleArrayPersonDto(
         length?: number,
         template?: Factory<PersonDto>
-    ): Array<PersonDto> {
+    ): readonly PersonDto[] {
         return this.randomArray(
             () => this.samplePersonDto(template),
             length ?? this.arrayLength()
@@ -707,7 +707,7 @@ export class TestSampleData {
     sampleArrayUpdateErrorDto(
         length?: number,
         factory?: (sampleData: TestSampleData) => UpdateErrorDto
-    ): Array<UpdateErrorDto> {
+    ): readonly UpdateErrorDto[] {
         return this.randomArray(
             () => this.sampleUpdateErrorDto(factory),
             length ?? this.arrayLength()

--- a/snapshotTests/snapshot/typeHierarchy/model.ts
+++ b/snapshotTests/snapshot/typeHierarchy/model.ts
@@ -34,7 +34,7 @@ export const DogDtoBreedEnumValues = [
     "Husky",
     "Retriever",
     "Shepherd",
-];
+] as const;
 
 export type DogDtoBreedEnum = typeof DogDtoBreedEnumValues[number];
 
@@ -53,6 +53,6 @@ export type PetDto =
 export const PetDtoDescriminators = [
     "Cat",
     "Dog",
-];
+] as const;
 
 export type PetDtoDescriminator = typeof PetDtoDescriminators[number];

--- a/snapshotTests/snapshot/typeHierarchy/test/modelTest.ts
+++ b/snapshotTests/snapshot/typeHierarchy/test/modelTest.ts
@@ -35,12 +35,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -127,15 +127,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -147,7 +147,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -223,7 +223,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -324,7 +324,7 @@ export class TestSampleData {
     sampleArrayAddressDto(
         length?: number,
         template?: Factory<AddressDto>
-    ): Array<AddressDto> {
+    ): readonly AddressDto[] {
         return this.randomArray(
             () => this.sampleAddressDto(template),
             length ?? this.arrayLength()
@@ -374,7 +374,7 @@ export class TestSampleData {
     sampleArrayCatDto(
         length?: number,
         template?: Factory<CatDto>
-    ): Array<CatDto> {
+    ): readonly CatDto[] {
         return this.randomArray(
             () => this.sampleCatDto(template),
             length ?? this.arrayLength()
@@ -424,7 +424,7 @@ export class TestSampleData {
     sampleArrayDogDto(
         length?: number,
         template?: Factory<DogDto>
-    ): Array<DogDto> {
+    ): readonly DogDto[] {
         return this.randomArray(
             () => this.sampleDogDto(template),
             length ?? this.arrayLength()
@@ -468,7 +468,7 @@ export class TestSampleData {
     sampleArrayPetBaseDto(
         length?: number,
         template?: Factory<PetBaseDto>
-    ): Array<PetBaseDto> {
+    ): readonly PetBaseDto[] {
         return this.randomArray(
             () => this.samplePetBaseDto(template),
             length ?? this.arrayLength()
@@ -503,7 +503,7 @@ export class TestSampleData {
     sampleArrayPetDto(
         length?: number,
         factory?: (sampleData: TestSampleData) => PetDto
-    ): Array<PetDto> {
+    ): readonly PetDto[] {
         return this.randomArray(
             () => this.samplePetDto(factory),
             length ?? this.arrayLength()

--- a/snapshotTests/snapshot/websockets/model.ts
+++ b/snapshotTests/snapshot/websockets/model.ts
@@ -61,7 +61,7 @@ export type WebSocketCommandDto =
 export const WebSocketCommandDtoDescriminators = [
     "createPerson",
     "updatePerson",
-];
+] as const;
 
 export type WebSocketCommandDtoDescriminator = typeof WebSocketCommandDtoDescriminators[number];
 
@@ -72,6 +72,6 @@ export type WebSocketRequestDto =
 
 export const WebSocketRequestDtoDescriminators = [
     "Subscribe",
-];
+] as const;
 
 export type WebSocketRequestDtoDescriminator = typeof WebSocketRequestDtoDescriminators[number];

--- a/snapshotTests/snapshot/websockets/test/modelTest.ts
+++ b/snapshotTests/snapshot/websockets/test/modelTest.ts
@@ -40,12 +40,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -138,15 +138,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -158,7 +158,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -234,7 +234,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -359,7 +359,7 @@ export class TestSampleData {
     sampleArrayChangeTrackedDto(
         length?: number,
         template?: Factory<ChangeTrackedDto>
-    ): Array<ChangeTrackedDto> {
+    ): readonly ChangeTrackedDto[] {
         return this.randomArray(
             () => this.sampleChangeTrackedDto(template),
             length ?? this.arrayLength()
@@ -389,7 +389,7 @@ export class TestSampleData {
     sampleArrayCreatePersonCommandDto(
         length?: number,
         template?: Factory<CreatePersonCommandDto>
-    ): Array<CreatePersonCommandDto> {
+    ): readonly CreatePersonCommandDto[] {
         return this.randomArray(
             () => this.sampleCreatePersonCommandDto(template),
             length ?? this.arrayLength()
@@ -443,7 +443,7 @@ export class TestSampleData {
     sampleArrayPersonDto(
         length?: number,
         template?: Factory<PersonDto>
-    ): Array<PersonDto> {
+    ): readonly PersonDto[] {
         return this.randomArray(
             () => this.samplePersonDto(template),
             length ?? this.arrayLength()
@@ -517,7 +517,7 @@ export class TestSampleData {
     sampleArrayPersonSnapshotDto(
         length?: number,
         template?: Factory<PersonSnapshotDto>
-    ): Array<PersonSnapshotDto> {
+    ): readonly PersonSnapshotDto[] {
         return this.randomArray(
             () => this.samplePersonSnapshotDto(template),
             length ?? this.arrayLength()
@@ -566,7 +566,7 @@ export class TestSampleData {
     sampleArrayStringSnapshotDto(
         length?: number,
         template?: Factory<StringSnapshotDto>
-    ): Array<StringSnapshotDto> {
+    ): readonly StringSnapshotDto[] {
         return this.randomArray(
             () => this.sampleStringSnapshotDto(template),
             length ?? this.arrayLength()
@@ -586,7 +586,7 @@ export class TestSampleData {
     sampleArraySubscribeDto(
         length?: number,
         template?: Factory<SubscribeDto>
-    ): Array<SubscribeDto> {
+    ): readonly SubscribeDto[] {
         return this.randomArray(
             () => this.sampleSubscribeDto(template),
             length ?? this.arrayLength()
@@ -606,7 +606,7 @@ export class TestSampleData {
     sampleArrayUnsubscribeDto(
         length?: number,
         template?: Factory<UnsubscribeDto>
-    ): Array<UnsubscribeDto> {
+    ): readonly UnsubscribeDto[] {
         return this.randomArray(
             () => this.sampleUnsubscribeDto(template),
             length ?? this.arrayLength()
@@ -636,7 +636,7 @@ export class TestSampleData {
     sampleArrayUpdatePersonCommandDto(
         length?: number,
         template?: Factory<UpdatePersonCommandDto>
-    ): Array<UpdatePersonCommandDto> {
+    ): readonly UpdatePersonCommandDto[] {
         return this.randomArray(
             () => this.sampleUpdatePersonCommandDto(template),
             length ?? this.arrayLength()
@@ -671,7 +671,7 @@ export class TestSampleData {
     sampleArrayWebSocketCommandDto(
         length?: number,
         factory?: (sampleData: TestSampleData) => WebSocketCommandDto
-    ): Array<WebSocketCommandDto> {
+    ): readonly WebSocketCommandDto[] {
         return this.randomArray(
             () => this.sampleWebSocketCommandDto(factory),
             length ?? this.arrayLength()
@@ -697,7 +697,7 @@ export class TestSampleData {
     sampleArrayWebSocketMessageDto(
         length?: number,
         factory?: (sampleData: TestSampleData) => WebSocketMessageDto
-    ): Array<WebSocketMessageDto> {
+    ): readonly WebSocketMessageDto[] {
         return this.randomArray(
             () => this.sampleWebSocketMessageDto(factory),
             length ?? this.arrayLength()
@@ -727,7 +727,7 @@ export class TestSampleData {
     sampleArrayWebSocketRequestDto(
         length?: number,
         factory?: (sampleData: TestSampleData) => WebSocketRequestDto
-    ): Array<WebSocketRequestDto> {
+    ): readonly WebSocketRequestDto[] {
         return this.randomArray(
             () => this.sampleWebSocketRequestDto(factory),
             length ?? this.arrayLength()

--- a/src/main/resources/typescript-fetch-api/modelEnum.handlebars
+++ b/src/main/resources/typescript-fetch-api/modelEnum.handlebars
@@ -4,7 +4,7 @@ export const {{classname}}Values = [
     {{{value}}},
     {{~/enumVars}}
 {{~/allowableValues}}
-];
+] as const;
 {{#if description}}
 /**
  * {{{description}}}

--- a/src/main/resources/typescript-fetch-api/modelGeneric.handlebars
+++ b/src/main/resources/typescript-fetch-api/modelGeneric.handlebars
@@ -28,7 +28,7 @@ export const {{enumName}}Values = [
     {{{value}}},
     {{~/enumVars}}
 {{~/allowableValues}}
-];
+] as const;
 {{#if description}}
 /**
  * {{{description}}}

--- a/src/main/resources/typescript-fetch-api/modelOneOf.handlebars
+++ b/src/main/resources/typescript-fetch-api/modelOneOf.handlebars
@@ -14,7 +14,7 @@ export const {{classname}}Descriminators = [
 {{~#mappedModels}}
     "{{mappingName}}",
 {{~/mappedModels}}
-];
+] as const;
 {{/discriminator}}
 export type {{classname}}Descriminator = typeof {{classname}}Descriminators[number];
 {{~/and}}

--- a/src/main/resources/typescript-fetch-api/modelTest.handlebars
+++ b/src/main/resources/typescript-fetch-api/modelTest.handlebars
@@ -43,12 +43,12 @@ export class Random {
         return this.nextInt(2) == 0;
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return options[this.nextInt(options.length)];
     }
 
-    pickSome<T>(options: Array<T>, n?: number): T[] {
-        const shuffled = options.sort(() => 0.5 - this.next());
+    pickSome<T>(options: readonly T[], n?: number): T[] {
+        const shuffled = [...options].sort(() => 0.5 - this.next());
         return shuffled.slice(0, n || this.nextInt(options.length));
     }
 
@@ -133,15 +133,15 @@ export class TestSampleData {
         return this.random.nextBoolean();
     }
 
-    pickOne<T>(options: Array<T>): T {
+    pickOne<T>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickOneString<T extends string>(options: Array<T>): T {
+    pickOneString<T extends string>(options: readonly T[]): T {
         return this.random.pickOne(options);
     }
 
-    pickSome<T>(options: Array<T>): T[] {
+    pickSome<T>(options: readonly T[]): T[] {
         return this.random.pickSome(options);
     }
 
@@ -153,7 +153,7 @@ export class TestSampleData {
         return this.pickOne(["foo", "bar", "baz"]);
     }
 
-    randomArray<T>(generator: (n: number) => T, length?: number): T[] {
+    randomArray<T>(generator: (n: number) => T, length?: number): readonly T[] {
         if (!length) length = this.nextInt(3) + 1;
         return Array.from({ length }).map((_, index) => generator(index));
     }
@@ -229,7 +229,7 @@ export class TestSampleData {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    sampleArrayArray<T>(length?: number): Array<Array<T>> {
+    sampleArrayArray<T>(length?: number): readonly T[] {
         return [];
     }
 
@@ -359,7 +359,7 @@ export class TestSampleData {
         length?: number,{{#if oneOf}}
         factory?: (sampleData: TestSampleData) => {{classname}}{{else}}
         template?: Factory<{{classname}}>{{/if}}
-    ){{/isEnum}}{{#isEnum}}(length?: number){{/isEnum}}: Array<{{classname}}> {
+    ){{/isEnum}}{{#isEnum}}(length?: number){{/isEnum}}: readonly {{classname}}[] {
         return this.randomArray(
             () => this.sample{{classname}}({{#if oneOf}}factory{{else}}{{^isEnum}}template{{/isEnum}}{{/if}}),
             length ?? this.arrayLength()


### PR DESCRIPTION
makes the type derived from the array a lot more useful, as the const assertion will be a lot more specific than the type assertion, making it similar to a union type